### PR TITLE
Removed IP field from node unmarshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.2 - 2018-09-14
+### Changed
+- Removed IP field from Node struct. It was not required as part of collection and could cause an error as the value could be a single string or an array of strings.
+
 ## 0.1.1 - 2018-09-13
 ### Added
 - Implemented client authentication

--- a/src/elasticsearch.go
+++ b/src/elasticsearch.go
@@ -25,7 +25,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.elasticsearch"
-	integrationVersion = "0.1.1"
+	integrationVersion = "0.1.2"
 )
 
 var (

--- a/src/metric_definition.go
+++ b/src/metric_definition.go
@@ -157,7 +157,6 @@ type NodeCounts struct {
 type Node struct {
 	Name       *string         `json:"name"`
 	Host       *string         `json:"host"`
-	IP         *string         `json:"ip"`
 	Indices    *NodeIndices    `json:"indices"`
 	Breakers   *NodeBreakers   `json:"breakers"`
 	Process    *NodeProcess    `json:"process"`


### PR DESCRIPTION
#### Description of the changes

Removed the IP field from the Node struct as it was not needed to collect data and added risk of an unmarshalling failure. The IP field in the JSON could either be a string or an array of strings.

#### PR Review Checklist
### Author

- [X] add a risk label after carefully considering the "blast radius" of your changes
- [X] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [X] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
