### PR TITLE
Add LocalHostname argument so that inventory host can be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.3 - 2018-09-25
+### Added
+- Added local hostname argument to allow for overriding "localhost" as the host from which to collect inventory data.
+
 ## 0.1.2 - 2018-09-14
 ### Changed
 - Removed IP field from Node struct. It was not required as part of collection and could cause an error as the value could be a single string or an array of strings.

--- a/elasticsearch-config.yml.sample
+++ b/elasticsearch-config.yml.sample
@@ -6,6 +6,7 @@ instances:
     arguments:
       config_path: <absolute path to the ElasticSearch configuration .yml file. (default "/etc/elasticsearch/elasticsearch.yml")>
       hostname: <hostname or IP where Elasticsearch Node is running. (default "localhost")>
+      local_hostname: <hostname or IP of the Elasticsearch node from which to collect inventory data. (default "localhost")>
       username: <username for accessing Elasticsearch Node>
       password: <password for the given user.>
       port: <port on which Elasticsearch Node is listening. (default 9200)>

--- a/src/client.go
+++ b/src/client.go
@@ -42,9 +42,9 @@ type errorBody struct {
 }
 
 // NewClient creates a new Elasticsearch http client.
-// The hostnameOverride parameter specifies a hostname that the client should connect to.
+// The hostname parameter specifies the hostname that the client should connect to.
 // Passing in an empty string causes the client to use the hostname specified in the command-line args. (default behavior)
-func NewClient(hostnameOverride string) (*HTTPClient, error) {
+func NewClient(hostname string) (*HTTPClient, error) {
 	httpClient, err := nrHttp.New(args.CABundleFile, args.CABundleDir, time.Duration(args.Timeout)*time.Second)
 	if err != nil {
 		return nil, err
@@ -60,12 +60,6 @@ func NewClient(hostnameOverride string) (*HTTPClient, error) {
 			if args.UseSSL {
 				protocol = "https"
 			}
-
-			hostname := args.Hostname
-			if hostnameOverride != "" {
-				hostname = hostnameOverride
-			}
-
 			return fmt.Sprintf("%s://%s:%d", protocol, hostname, args.Port)
 		}(),
 	}, nil

--- a/src/client_test.go
+++ b/src/client_test.go
@@ -31,30 +31,13 @@ func TestNewClient(t *testing.T) {
 	for _, tc := range testCases {
 		setupTestArgs()
 		args.Hostname, args.Port, args.UseSSL = hostname, port, tc.useSSL
-		client, err := NewClient("")
+		client, err := NewClient(args.Hostname)
 		if err != nil {
 			t.Errorf("Unexpected error: %s", err.Error())
 		} else {
 			if client.baseURL != tc.wantURL {
 				t.Errorf("Expected BaseURL '%s' got '%s'", tc.wantURL, client.baseURL)
 			}
-		}
-	}
-}
-
-func TestHostnameOverride(t *testing.T) {
-	hostname, port, ssl := "host", 9, false
-	hostOverride := "overridden"
-	expectedURL := fmt.Sprintf("http://%s:%d", hostOverride, port)
-
-	setupTestArgs()
-	args.Hostname, args.Port, args.UseSSL = hostname, port, ssl
-	client, err := NewClient(hostOverride)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err.Error())
-	} else {
-		if client.baseURL != expectedURL {
-			t.Errorf("Expected BaseURL '%s' got '%s'", expectedURL, client.baseURL)
 		}
 	}
 }

--- a/src/elasticsearch.go
+++ b/src/elasticsearch.go
@@ -26,7 +26,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.elasticsearch"
-	integrationVersion = "0.1.2"
+	integrationVersion = "0.1.3"
 )
 
 var (

--- a/src/elasticsearch.go
+++ b/src/elasticsearch.go
@@ -11,6 +11,7 @@ import (
 type argumentList struct {
 	sdkArgs.DefaultArgumentList
 	Hostname         string `default:"localhost" help:"Hostname or IP where Elasticsearch Node is running."`
+	LocalHostname    string `default:"localhost" help:"Hostname or IP of the Elasticsearch node from which to collect inventory."`
 	Port             int    `default:"9200" help:"Port on which Elasticsearch Node is listening."`
 	Username         string `default:"" help:"Username for accessing Elasticsearch Node"`
 	Password         string `default:"" help:"Password for the given user."`
@@ -38,7 +39,7 @@ func main() {
 	logErrorAndExit(err)
 
 	// Create a client for metrics
-	metricsClient, err := NewClient("")
+	metricsClient, err := NewClient(args.Hostname)
 	logErrorAndExit(err)
 
 	if args.All() || args.Metrics {
@@ -47,7 +48,7 @@ func main() {
 
 	// Create a client for inventory. Inventory needs to make REST calls against
 	// localhost to get information relative to this node only.
-	inventoryClient, err := NewClient("localhost")
+	inventoryClient, err := NewClient(args.LocalHostname)
 	logErrorAndExit(err)
 
 	if args.All() || args.Inventory {


### PR DESCRIPTION
#### Description of the changes

Instead of hardcoding localhost as the host to collect inventory from, allow it to be configured. This allows for more flexibility in setting up the monitoring in case Elasticsearch is configured to not listen on localhost.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
