### PR TITLE
Added in the ability to pass in a ClusterEnvironment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Session.vim
 # VSCode
 .vscode
 debug
+
+#GoLand
+.idea

--- a/src/elasticsearch.go
+++ b/src/elasticsearch.go
@@ -10,19 +10,20 @@ import (
 
 type argumentList struct {
 	sdkArgs.DefaultArgumentList
-	Hostname         string `default:"localhost" help:"Hostname or IP where Elasticsearch Node is running."`
-	LocalHostname    string `default:"localhost" help:"Hostname or IP of the Elasticsearch node from which to collect inventory."`
-	Port             int    `default:"9200" help:"Port on which Elasticsearch Node is listening."`
-	Username         string `default:"" help:"Username for accessing Elasticsearch Node"`
-	Password         string `default:"" help:"Password for the given user."`
-	UseSSL           bool   `default:"false" help:"Signals whether to use SSL or not. Certificate bundle must be supplied"`
-	CABundleFile     string `default:"" help:"Alternative Certificate Authority bundle file"`
-	CABundleDir      string `default:"" help:"Alternative Certificate Authority bundle directory"`
-	Timeout          int    `default:"30" help:"Timeout for an API call"`
-	ConfigPath       string `default:"/etc/elasticsearch/elasticsearch.yml" help:"Path to the ElasticSearch configuration .yml file."`
-	CollectIndices   bool   `default:"true" help:"Signals whether to collect indices metrics or not"`
-	CollectPrimaries bool   `default:"true" help:"Signals whether to collect primaries metrics or not"`
-	IndicesRegex     string `default:"" help:"JSON array of index names from which to collect metrics"`
+	Hostname           string `default:"localhost" help:"Hostname or IP where Elasticsearch Node is running."`
+	LocalHostname      string `default:"localhost" help:"Hostname or IP of the Elasticsearch node from which to collect inventory."`
+	ClusterEnvironment string `default:"" help:"A way to further specify which cluster we are gathering data for, example: 'staging'"`
+	Port               int    `default:"9200" help:"Port on which Elasticsearch Node is listening."`
+	Username           string `default:"" help:"Username for accessing Elasticsearch Node"`
+	Password           string `default:"" help:"Password for the given user."`
+	UseSSL             bool   `default:"false" help:"Signals whether to use SSL or not. Certificate bundle must be supplied"`
+	CABundleFile       string `default:"" help:"Alternative Certificate Authority bundle file"`
+	CABundleDir        string `default:"" help:"Alternative Certificate Authority bundle directory"`
+	Timeout            int    `default:"30" help:"Timeout for an API call"`
+	ConfigPath         string `default:"/etc/elasticsearch/elasticsearch.yml" help:"Path to the ElasticSearch configuration .yml file."`
+	CollectIndices     bool   `default:"true" help:"Signals whether to collect indices metrics or not"`
+	CollectPrimaries   bool   `default:"true" help:"Signals whether to collect primaries metrics or not"`
+	IndicesRegex       string `default:"" help:"JSON array of index names from which to collect metrics"`
 }
 
 const (
@@ -44,7 +45,7 @@ func main() {
 	logErrorAndExit(err)
 
 	if args.All() || args.Metrics {
-		populateMetrics(i, metricsClient)
+		populateMetrics(i, metricsClient, args.ClusterEnvironment)
 	}
 
 	// Create a client for inventory. Inventory needs to make REST calls against

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -13,13 +13,13 @@ import (
 const indexLimit = 500
 
 // populateMetrics wrapper to call each of the individual populate functions
-func populateMetrics(i *integration.Integration, client Client) {
+func populateMetrics(i *integration.Integration, client Client, env string) {
 	err := populateNodesMetrics(i, client)
 	if err != nil {
 		log.Error("There was an error populating metrics for nodes: %v", err)
 	}
 
-	err = populateClusterMetrics(i, client)
+	err = populateClusterMetrics(i, client, env)
 	if err != nil {
 		log.Error("There was an error populating metrics for clusters: %v", err)
 	}
@@ -60,7 +60,7 @@ func setNodesMetricsResponse(integration *integration.Integration, resp *NodeRes
 	}
 }
 
-func populateClusterMetrics(i *integration.Integration, client Client) error {
+func populateClusterMetrics(i *integration.Integration, client Client, env string) error {
 	log.Info("Collecting cluster metrics.")
 	clusterResponse := new(ClusterResponse)
 	err := client.Request(clusterEndpoint, &clusterResponse)
@@ -70,6 +70,9 @@ func populateClusterMetrics(i *integration.Integration, client Client) error {
 
 	if clusterResponse.Name == nil {
 		return fmt.Errorf("cannot set metric response, missing cluster name")
+	}
+	if env != "" {
+		*clusterResponse.Name = *clusterResponse.Name + ":" + env
 	}
 	return setMetricsResponse(i, clusterResponse, *clusterResponse.Name, "cluster")
 }
@@ -175,6 +178,7 @@ func getIndexFromCommon(indexName string, indexList map[string]*Index) (*Index, 
 // setMetricsResponse creates an entity and a metric set for the
 // type of response and calls MarshalMetrics using that response
 func setMetricsResponse(integration *integration.Integration, resp interface{}, name string, namespace string) error {
+
 	entity, err := integration.Entity(name, namespace)
 	if err != nil {
 		return err

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -85,7 +85,7 @@ func TestPopulateClusterMetrics(t *testing.T) {
 	client := createNewTestClient()
 	client.init("clusterStatsMetricsResult.json", clusterEndpoint, t)
 
-	populateClusterMetrics(i, client)
+	populateClusterMetrics(i, client, "")
 
 	sourceFile := filepath.Join("testdata", "clusterStatsMetricsResult.json")
 
@@ -108,7 +108,7 @@ func TestPopulateClusterMetrics_Error(t *testing.T) {
 	mockClient.ReturnRequestError = true
 
 	i := getTestingIntegration(t)
-	err := populateClusterMetrics(i, mockClient)
+	err := populateClusterMetrics(i, mockClient, "")
 	assert.Error(t, err, "should be an error")
 }
 


### PR DESCRIPTION
This will allow a user to configure the NRI ES integration to have the cluster name report with extra granularity about which environment it's in.
By default this is disabled, and only makes a difference when a user passes in the arg.

A example use case here is that a user has two ES clusters with the same name, but running in different environments.

#### Description of the changes

Add a detailed description and purpose of your changes.
Link the issue it solves (if there is one).

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
