### PR TITLE
Add suffix for selecting yml while packaging

### DIFF
--- a/Makefile-package.mk
+++ b/Makefile-package.mk
@@ -33,10 +33,10 @@ prep-pkg-env:
 	@echo "=== Main === [ prep-pkg-env ]: adding built binaries and configuration and definition files..."
 	@cp $(BINS_DIR)/$(BINARY_NAME) $(SOURCE_DIR)/var/db/newrelic-infra/newrelic-integrations/bin
 	@chmod 755 $(SOURCE_DIR)/var/db/newrelic-infra/newrelic-integrations/bin/*
-	@cp ./*.yml $(SOURCE_DIR)/var/db/newrelic-infra/newrelic-integrations/
-	@chmod 644 $(SOURCE_DIR)/var/db/newrelic-infra/newrelic-integrations/*.yml
-	@cp ./*.sample $(SOURCE_DIR)/etc/newrelic-infra/integrations.d/
-	@chmod 644 $(SOURCE_DIR)/etc/newrelic-infra/integrations.d/*.sample
+	@cp ./*-definition.yml $(SOURCE_DIR)/var/db/newrelic-infra/newrelic-integrations/
+	@chmod 644 $(SOURCE_DIR)/var/db/newrelic-infra/newrelic-integrations/*-definition.yml
+	@cp ./*-config.yml.sample $(SOURCE_DIR)/etc/newrelic-infra/integrations.d/
+	@chmod 644 $(SOURCE_DIR)/etc/newrelic-infra/integrations.d/*-config.yml.sample
 
 deb: prep-pkg-env
 	@echo "=== Main === [ deb ]: building DEB package..."


### PR DESCRIPTION
#### Description of the changes

Add suffix for selecting yml while packaging, that way we exclude common packages like, `papers_manifest.yml`

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
