### PR TITLE
New option `master_only`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.3.1 (2020-05-07)
+### Added
+- option `master_only` affection `command: all` only: Collect cluster metrics on the elected master only
+
 ## 4.3.0 (2020-04-27)
 ### Changed
 - Updated the SDK to the latest version

--- a/src/client.go
+++ b/src/client.go
@@ -16,6 +16,7 @@ const (
 	commonStatsEndpoint        = "/_stats"
 	clusterEndpoint            = "/_cluster/health"
 	indicesStatsEndpoint       = "/_cat/indices?format=json"
+	electedMasterNodeEndpoint  = "/_cat/master?h=id"
 )
 
 // HTTPClient represents a single connection to an Elasticsearch host

--- a/src/elasticsearch.go
+++ b/src/elasticsearch.go
@@ -26,11 +26,12 @@ type argumentList struct {
 	CollectIndices         bool   `default:"true" help:"Signals whether to collect indices metrics or not"`
 	CollectPrimaries       bool   `default:"true" help:"Signals whether to collect primaries metrics or not"`
 	IndicesRegex           string `default:"" help:"JSON array of index names from which to collect metrics"`
+	MasterOnly             bool   `default:"false" help:"Collect cluster metrics on the elected master only"`
 }
 
 const (
 	integrationName    = "com.newrelic.elasticsearch"
-	integrationVersion = "4.3.0"
+	integrationVersion = "4.3.1"
 )
 
 var (

--- a/src/metric_definition.go
+++ b/src/metric_definition.go
@@ -1,5 +1,15 @@
 package main
 
+// LocalNodeIdResponse struct (/_nodes/_local endpoint)
+type LocalNodeIdResponse struct {
+	Nodes map[string]*map `json:"nodes"`
+}
+
+// MasterNodeIdResponse struct (/_cat/master?h=id endpoint)
+type MasterNodeIdResponse struct {
+	ID string
+}
+
 // CommonMetrics struct
 type CommonMetrics struct {
 	All     *All `json:"_all"`


### PR DESCRIPTION
# New option `master_only`

#### Description of the changes
This new option fulfills requirement mentioned at https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/elasticsearch-monitoring-integration#config:
> Only one node agent should use the all command, as metrics are collected for the whole cluster.

Typically an Elasticsearch cluster has more master eligible nodes, so it's useless and too expensive to collect cluster metrics on all of them. This option gathers the actually elected master and continues with cluster metrics only on this one node.

That option is `false` by default what brings the same behaviour as previous versions - so it's fully compatible.

I was unable to compile and test it, because of dependency on obsoleted `govendor` tool:
```
► govendor sync
Error: Package "/g/nri-elasticsearch" not a go package or not in GOPATH.
```

#### PR Review Checklist
### Author
Kamil Jakubovic, kamil.jakubovic@sap.com

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [x] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
