### PR TITLE
Revert actions using hash instead of tag

### DIFF
--- a/.github/workflows/on_prerelease.yml
+++ b/.github/workflows/on_prerelease.yml
@@ -20,7 +20,7 @@ jobs:
     name: Run unit tests on *Nix
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -39,7 +39,7 @@ jobs:
         working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
         with:
           path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
       - name: Install Go
@@ -60,7 +60,7 @@ jobs:
         working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}
     steps:
       - name: Check out code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [test-nix, test-windows, test-integration-nix]
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -115,7 +115,7 @@ jobs:
         test-upgrade: [true,false]
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
         with:
           path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
       - name: Get PFX certificate from GH secrets

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -19,7 +19,7 @@ jobs:
     name: Run all static analysis checks
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - uses: newrelic/newrelic-infra-checkers@v1
       - name: Semgrep
         uses: returntocorp/semgrep-action@v1
@@ -37,7 +37,7 @@ jobs:
     name: Run unit tests on *Nix
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
         if: ${{env.DOCKER_LOGIN_AVAILABLE}}
         uses: docker/login-action@v2
@@ -57,7 +57,7 @@ jobs:
         working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
         with:
           path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
       - name: Install Go
@@ -78,7 +78,7 @@ jobs:
         working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}
     steps:
       - name: Check out code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
@@ -101,7 +101,7 @@ jobs:
     name: Test binary compilation for all platforms:arch
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
         if: ${{env.DOCKER_LOGIN_AVAILABLE}}
         uses: docker/login-action@v2

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -22,7 +22,7 @@ jobs:
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@0.12.0


### PR DESCRIPTION
I misread the PRs from renovate and merged PRs that changed the tag to a commit hash.

We don't know if renovate will update commits written like that and if renovate might stick to master instead of following tag conventions.

As this is an untested territory I prefer to revert the change and keep working with tags.