### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-## v5.3.1 - 2024-12-17
-
-### ⛓️ Dependencies
-- Updated golang patch version to v1.23.4
-
 ## v5.3.0 - 2024-10-08
 
 ### dependency


### PR DESCRIPTION
Revert changelog to retrigger the prerelease of Renovate bumps