### PR TITLE
chore(deps): update go module directive to v1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-elasticsearch
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/newrelic/infra-integrations-sdk/v3 v3.9.1

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-bookworm as builder
+FROM golang:1.26.6-bookworm as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/nri-elasticsearch
 COPY . .


### PR DESCRIPTION
This PR bumps the Go module directive from `1.26.5` to `1.26.6`.

**Why:** `1.26.5` is affected by several CVEs disclosed in the Go security release published 2026-08-13 (net/http, crypto/tls, encoding/asn1, encoding/xml, golang.org/x/mod). The renovate-raised alternative for this repo jumped straight to `1.27.0`, but the `ghcr.io/newrelic/coreint-automation:latest-go1.27.0-ubuntu16.04` builder image does not exist yet, so that PR cannot pass CI. The `go1.26.6` builder image is already published, so this smaller, safer bump is being raised manually to unblock CI and stay consistent with the other OHI repos that already picked up this patch via Renovate.